### PR TITLE
[RFR] Set PYTHONPATH to /usr/lib

### DIFF
--- a/apps/runner/exec.coffee
+++ b/apps/runner/exec.coffee
@@ -37,8 +37,12 @@ start_program = ->
       
       namespace.emit events.starting.id, running.resource.name
 
+      env = Object.create(process.env);
+      env.PYTHONPATH = "/usr/lib"
+
       running_process = spawn running.resource.binary.path, [], {
         cwd: Path.resolve running.resource.data_directory.path
+        env: env
       }
 
       running_process.on 'error', (data) ->


### PR DESCRIPTION
Fixes a crash when running python programs via the runner.