### PR TITLE
[RFR] Export as .zip (javascript version)

### DIFF
--- a/apps/programs/api-routes/projects.js
+++ b/apps/programs/api-routes/projects.js
@@ -6,6 +6,8 @@ Fs = require('fs');
 
 Tar = require('tar-stream');
 
+Zip = require('zip-stream');
+
 Q = require('q');
 
 Url = require('url');
@@ -197,6 +199,18 @@ router.get('/:project', function(request, response, next) {
             'application/octet-stream': 'application/octet-stream'
           });
           pack.pipe(Zlib.createGzip()).pipe(response);
+          pack.finalize();
+        });
+      } else if ((response_mode != null) && response_mode === 'zip') {
+        // reply .zip
+        pack = new Zip();
+        return project_resource.pack(pack).then(function(p) {
+          response.setHeader('Content-disposition', 'attachment; filename=' + project_resource.name + '.zip');
+          response.writeHead(200, {
+            'Content-Type': 'Content-Type',
+            'application/octet-stream': 'application/octet-stream'
+          });
+          pack.pipe(response);
           pack.finalize();
         });
       } else {

--- a/apps/programs/project.js
+++ b/apps/programs/project.js
@@ -81,9 +81,20 @@ pack_helper = function(pack, folder_resource, prefix) {
           var name;
           name = prefix + "/" + child.name;
           return Fs.readFile(child.path, function(error, content) {
-            pack.entry({
-              name: name
-            }, content);
+            console.log("pack entry name: " + name + " content: " + content);
+
+            if (pack.options && pack.options.zlib && (pack.options.zlib.level != null)) {
+              pack.entry(name, {
+                name: name
+              }, content);
+              resolve(child);
+            } else {
+              pack.entry({
+                name: name
+                }, content);
+                resolve(child);
+            }
+
             return resolve(child);
           });
         }));

--- a/apps/programs/project.js
+++ b/apps/programs/project.js
@@ -84,15 +84,13 @@ pack_helper = function(pack, folder_resource, prefix) {
             console.log("pack entry name: " + name + " content: " + content);
 
             if (pack.options && pack.options.zlib && (pack.options.zlib.level != null)) {
-              pack.entry(name, {
+              pack.entry(content, {
                 name: name
-              }, content);
-              resolve(child);
+              });
             } else {
               pack.entry({
                 name: name
-                }, content);
-                resolve(child);
+              }, content);
             }
 
             return resolve(child);

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "rimraf": "^2.5.0",
     "socket.io": "^1.3.7",
     "socket.io-client": "^1.3.7",
-    "tar-stream": "^1.3.1"
+    "tar-stream": "^1.3.1",
+    "zip-stream": "^0.8.0"
   },
   "devDependencies": {
     "browserify": "^8.0.1",

--- a/shared/client/views/download-project-modal.jade
+++ b/shared/client/views/download-project-modal.jade
@@ -7,6 +7,8 @@
     .col-md-2
     .col-md-8
       .list-group
+        a.list-group-item(ng-href="{{project_resource.links.self.href}}?mode=zip" download)
+          | Download {{project_resource.name}} as .zip archive
         a.list-group-item(ng-href="{{project_resource.links.self.href}}?mode=packed" download)
           | Download {{project_resource.name}} as .tar archive
         a.list-group-item(ng-href="{{project_resource.links.self.href}}?mode=compressed" download)


### PR DESCRIPTION
I have moved over the work by @swatkins in #31 since we have a new javascript version of the codebase.

I can confirm that it allows users to download a .zip if the project only contains a single file. 

If there are multiple files, there is an error:
````
events.js:72
        throw er; // Unhandled 'error' event
              ^
Error: already processing an entry
    at ArchiveOutputStream.entry (/home/josh/got/tmp/harrogate/node_modules/zip-stream/node_modules/compress-commons/lib/archivers/archive-output-stream.js:75:14)
    at ZipStream.entry (/home/josh/got/tmp/harrogate/node_modules/zip-stream/lib/zip-stream.js:105:49)
    at /home/josh/got/tmp/harrogate/apps/programs/project.js:87:20
    at fs.js:268:14
    at Object.oncomplete (fs.js:107:15)

stream.js:94
      throw er; // Unhandled stream error in pipe.
            ^
Error: read ECONNRESET
    at errnoException (net.js:901:11)
    at Pipe.onread (net.js:556:19)

````

This occurs when handling the second file in the project.  I'll look into it.