### PR TITLE
[WIP] Javascript download headers

### DIFF
--- a/apps/programs/api-routes/projects.js
+++ b/apps/programs/api-routes/projects.js
@@ -181,11 +181,9 @@ router.get('/:project', function(request, response, next) {
         // reply .tar
         pack = Tar.pack();
         return project_resource.pack(pack).then(function(p) {
+          response.setHeader("Content-Type", "application/zip");
           response.setHeader('Content-disposition', 'attachment; filename=' + project_resource.name + '.tar');
-          response.writeHead(200, {
-            'Content-Type': 'Content-Type',
-            'application/octet-stream': 'application/octet-stream'
-          });
+          response.writeHead(200);
           pack.pipe(response);
           pack.finalize();
         });
@@ -193,11 +191,9 @@ router.get('/:project', function(request, response, next) {
         // reply .tar.gz
         pack = Tar.pack();
         return project_resource.pack(pack).then(function(p) {
+          response.setHeader("Content-Type", "application/zip");
           response.setHeader('Content-disposition', 'attachment; filename=' + project_resource.name + '.tar.gz');
-          response.writeHead(200, {
-            'Content-Type': 'Content-Type',
-            'application/octet-stream': 'application/octet-stream'
-          });
+          response.writeHead(200);
           pack.pipe(Zlib.createGzip()).pipe(response);
           pack.finalize();
         });
@@ -205,11 +201,9 @@ router.get('/:project', function(request, response, next) {
         // reply .zip
         pack = new Zip();
         return project_resource.pack(pack).then(function(p) {
+          response.setHeader("Content-Type", "application/zip");
           response.setHeader('Content-disposition', 'attachment; filename=' + project_resource.name + '.zip');
-          response.writeHead(200, {
-            'Content-Type': 'Content-Type',
-            'application/octet-stream': 'application/octet-stream'
-          });
+          response.writeHead(200);
           pack.pipe(response);
           pack.finalize();
         });


### PR DESCRIPTION
Supersedes #40 which had the wrong base branch.

This PR fixes the internal server errors that occur when downloading projects as .tar .tar.gz and .zip formats.

**Known issue:**
multifile zip archives are failing with the message:
````
events.js:141
      throw er; // Unhandled 'error' event
      ^

Error: already processing an entry
    at ArchiveOutputStream.entry (/harrogate/node_modules/compress-commons/lib/archivers/archive-output-stream.js:75:14)
    at ZipStream.entry (/harrogate/node_modules/zip-stream/lib/zip-stream.js:105:49)
    at /harrogate/apps/programs/project.js:86:20
    at FSReqWrap.readFileAfterClose [as oncomplete] (fs.js:404:3)
````
...which seems very similar to the bug fixed by https://github.com/kipr/harrogate/pull/39

