### PR TITLE
[RFR] Fixing DOM reference errors when cancelling adding projects or users

### DIFF
--- a/apps/kiss/resources/kiss-view-controller.js
+++ b/apps/kiss/resources/kiss-view-controller.js
@@ -321,7 +321,7 @@ exports.controller = function($scope, $rootScope, $location, $http, $timeout, Ap
     $('#new-project').modal('show');
   };
   $scope.hide_add_project_modal = function() {
-    return $('#new-project').modal('hide');
+    $('#new-project').modal('hide');
   };
   $scope.add_project = function() {
     $('#new-project').modal('hide');
@@ -363,7 +363,7 @@ exports.controller = function($scope, $rootScope, $location, $http, $timeout, Ap
     $('#new-user').modal('show');
   };
   $scope.hide_new_user_modal = function() {
-    return $('#new-user').modal('hide');
+    $('#new-user').modal('hide');
   };
 
   $scope.add_user = function() {


### PR DESCRIPTION
We were getting errors when cancelling adding users or projects, such as:

````
Error: [$parse:isecdom] Referencing DOM nodes in Angular expressions is disallowed! Expression: hide_new_user_modal()
http://errors.angularjs.org/1.5.8/$parse/isecdom?p0=hide_new_user_modal()
   at http://127.0.0.1:8888/scripts/harrogate-index-app.js:1845:12
   at ensureSafeObject (http://127.0.0.1:8888/scripts/harrogate-index-app.js:15790:13)
   at fn (eval at <anonymous> (http://127.0.0.1:8888/scripts/harrogate-index-app.js:16594:15), <anonymous>:4:243)
   at expensiveCheckFn (http://127.0.0.1:8888/scripts/harrogate-index-app.js:17683:18)
   at callback (http://127.0.0.1:8888/scripts/harrogate-index-app.js:27662:17)
   at Scope.$eval (http://127.0.0.1:8888/scripts/harrogate-index-app.js:19459:28)
   at Scope.$apply (http://127.0.0.1:8888/scripts/harrogate-index-app.js:19559:25)
   at HTMLButtonElement.<anonymous> (http://127.0.0.1:8888/scripts/harrogate-index-app.js:27667:23)
   at HTMLButtonElement.n.event.dispatch (http://127.0.0.1:8888/scripts/jquery.min.js:3:7537)
   at HTMLButtonElement.r.handle (http://127.0.0.1:8888/scripts/jquery.min.js:3:5620)
````

https://docs.angularjs.org/error/$parse/isecdom