### PR TITLE
[RFR] lodash 4.8.0 needed for archiver 1.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "express-session": "^1.12.1",
     "font-awesome": "^4.5.0",
     "jquery": "^2.1.4",
-    "lodash": "^3.10.1",
+    "lodash": "^4.8.0",
     "mime": "^1.3.4",
     "mkdirp": "^0.5.1",
     "passport": "^0.3.2",


### PR DESCRIPTION
bitbake is breaking all of a sudden...  It may be because we are getting archiver 1.1.0 instead of 1.0.1