### PR TITLE
[RFR] Switching users closes the project

### DIFF
--- a/apps/kiss/resources/kiss-view-controller.js
+++ b/apps/kiss/resources/kiss-view-controller.js
@@ -64,7 +64,7 @@ exports.controller = function($scope, $rootScope, $location, $http, $timeout, Ap
             } else {
               $location.search('project', null);
             }
-            
+
           }
         });
         $http.get(projects_resource.uri + '/users').success(function(data, status, headers, config) {
@@ -405,6 +405,8 @@ exports.controller = function($scope, $rootScope, $location, $http, $timeout, Ap
   }
 
   $scope.$watch('active_user', function(newValue, oldValue) {
+    $scope.close_project();
+    $scope.close_file();
     $scope.reload_ws();
   });
 


### PR DESCRIPTION
Previously, if you are on the default user, displaying main.c from their project, switching to another user keeps the default user’s project and source code displayed.