### PR TITLE
[RFR] Reset project and file name to  when a new add-project modal is opened

### DIFF
--- a/apps/kiss/resources/kiss-view-controller.js
+++ b/apps/kiss/resources/kiss-view-controller.js
@@ -318,6 +318,8 @@ exports.controller = function($scope, $rootScope, $location, $http, $timeout, Ap
     return $scope.display_file_menu = true;
   };
   $scope.show_add_project_modal = function() {
+    $scope.change_filename();
+    $('#projectName').val(undefined);
     $('#new-project').modal('show');
   };
   $scope.hide_add_project_modal = function() {


### PR DESCRIPTION
I didn't reset the language back to the default ('C').  I ran into problems with that since ``defaultProgrammingLanguage`` is manipulated as the ``ng-model`` which didn't seem to play nice with us resetting it inside of ``ng-change``