### PR TITLE
[RFR] When a new project is created, it is loaded as the active project

### DIFF
--- a/apps/kiss/resources/kiss-view-controller.js
+++ b/apps/kiss/resources/kiss-view-controller.js
@@ -335,6 +335,7 @@ exports.controller = function($scope, $rootScope, $location, $http, $timeout, Ap
           language: $("#programmingLanguage").val(),
           src_file_name: $("#sourceFileName").val()
         }).success(function(data, status, headers, config) {
+          $location.search('project', $("#projectName").val());
           $scope.reload_ws();
         });
       }


### PR DESCRIPTION
Before this change, the active project was left open.