### PR TITLE
[RFR] Fixing Project Explorer file and project name vertical text overflow

### DIFF
--- a/shared/client/css/style.css
+++ b/shared/client/css/style.css
@@ -130,7 +130,7 @@
 {
     .panel-stretch > .scrollable-panel-body-container
     {
-        max-height: calc(100% - 43.333px);
+        max-height: calc(100% - 80px);
         overflow: auto;
     }
 


### PR DESCRIPTION
The list of projects/files was overflowing because the height was not calculated correctly.  This isn't a very robust fix.

![overflow](https://cloud.githubusercontent.com/assets/1850915/20544762/2ade78be-b0d1-11e6-8d50-0f18577e9d18.png)

