### PR TITLE
Adding scratch build to python3

### DIFF
--- a/setup/workspace.json
+++ b/setup/workspace.json
@@ -1,0 +1,1 @@
+"/home/root/Documents/KISS"


### PR DESCRIPTION
I plan to put the python 3 branch into v27 so I am merging the scratch branch into it.

When building all the software from scratch, scratch fixes some errors that arise.