### PR TITLE
C++, different syntax highlight, compiler args

### DIFF
--- a/apps/compiler/api-routes/compile.js
+++ b/apps/compiler/api-routes/compile.js
@@ -81,6 +81,10 @@ router.post('/', function(request, response, next) {
       } else if (language.toLowerCase() === 'python') {
         compilation_environment = require('../compilation-environments/python/python.js');
       }
+      else if (language.toLowerCase() === 'c++') {
+        compilation_environment = require('../compilation-environments/c++/g++.js');
+      }
+      
       return compilation_environment.compile(project_resource, function(error, stdout, stderr) {
         var result;
         result = {

--- a/apps/compiler/compilation-environments/c++/g++.js
+++ b/apps/compiler/compilation-environments/c++/g++.js
@@ -1,0 +1,51 @@
+var Config, Path, exec;
+
+exec = require('child_process').exec;
+
+Path = require('path');
+
+Config = require_harrogate_module('config.js');
+
+const fs = require("fs");
+
+module.exports = {
+  compile: function (project_resource, cb) {
+    project_resource.src_directory.is_valid().then(function (valid) {
+      if (!valid) {
+        throw new ServerError(404, 'Project ' + project_resource.name + ' does not contain any source files');
+      }
+      return project_resource.src_directory.get_children();
+    }).then(function (src_files) {
+      var gpp_cmd, i, len, src;
+      gpp_cmd = "g++ -I\"" + project_resource.include_directory.path + "\" -I\"" + Config.ext_deps.include_path + "\" -Wall ";
+      for (i = 0, len = src_files.length; i < len; i++) {
+        src = src_files[i];
+        if (Path.basename(src.path).charAt(0) !== '.') {
+          gpp_cmd += '"' + src.path + "\" ";
+        }
+      }
+      gpp_cmd += "-L\"" + Config.ext_deps.lib_path + "\" -o \"" + project_resource.binary.path + "\" ";
+
+      // extra support for extra compiler args
+      if (fs.existsSync(project_resource.data_directory.path + "/config.json")) {
+        try{
+            options = JSON.parse(fs.readFileSync(project_resource.data_directory.path + "/config.json", { encoding: 'ascii', flag: 'r' }));
+
+            if ("compilerArgs" in options) {
+                options["compilerArgs"].forEach(element => {
+                gpp_cmd += element + " ";
+                });
+            }
+        }
+        catch (e){
+            console.log("failed because of");
+            console.log(e);
+        }
+      }
+
+      exec(gpp_cmd, cb);
+    })["catch"](function (e) {
+      cb(e);
+    }).done();
+  }
+};

--- a/apps/compiler/compilation-environments/c++/g++.js
+++ b/apps/compiler/compilation-environments/c++/g++.js
@@ -24,22 +24,22 @@ module.exports = {
           gpp_cmd += '"' + src.path + "\" ";
         }
       }
-      gpp_cmd += "-L\"" + Config.ext_deps.lib_path + "\" -o \"" + project_resource.binary.path + "\" ";
+      gpp_cmd += "-L\"" + Config.ext_deps.lib_path + "\" -lwallaby -lm -o \"" + project_resource.binary.path + "\" -lz -lpthread ";
 
       // extra support for extra compiler args
       if (fs.existsSync(project_resource.data_directory.path + "/config.json")) {
-        try{
-            options = JSON.parse(fs.readFileSync(project_resource.data_directory.path + "/config.json", { encoding: 'ascii', flag: 'r' }));
+        try {
+          options = JSON.parse(fs.readFileSync(project_resource.data_directory.path + "/config.json", { encoding: 'ascii', flag: 'r' }));
 
-            if ("compilerArgs" in options) {
-                options["compilerArgs"].forEach(element => {
-                gpp_cmd += element + " ";
-                });
-            }
+          if ("compilerArgs" in options) {
+            options["compilerArgs"].forEach(element => {
+              gpp_cmd += element + " ";
+            });
+          }
         }
-        catch (e){
-            console.log("failed because of");
-            console.log(e);
+        catch (e) {
+          console.log("failed because of");
+          console.log(e);
         }
       }
 

--- a/apps/kiss/resources/index.jade
+++ b/apps/kiss/resources/index.jade
@@ -187,18 +187,18 @@ block view-content
                 th(colspan="3")
                   | {{project.name}}
 
-              tr.cursor-pointer(ng-if='selected_project.parameters.language === "C" && selected_project === project && active_user.data.mode !== "Simple"' ng-class='{active: selected_file, info: !selected_file}')
+              tr.cursor-pointer(ng-if='(selected_project.parameters.language === "C" || selected_project.parameters.language === "C++") && selected_project === project && active_user.data.mode !== "Simple"' ng-class='{active: selected_file, info: !selected_file}')
                 th
                 th(colspan="2")
                   | Include Files
-              tr.cursor-pointer(ng-if='selected_project.parameters.language === "C" && selected_project === project && active_user.data.mode !== "Simple"' ng-repeat = 'file in project_resource.include_files' ng-class='{active: selected_file && selected_file != file, info: !selected_file || selected_file === file}' ng-click='select_file(file, "include")')
+              tr.cursor-pointer(ng-if='(selected_project.parameters.language === "C" || selected_project.parameters.language === "C++") && selected_project === project && active_user.data.mode !== "Simple"' ng-repeat = 'file in project_resource.include_files' ng-class='{active: selected_file && selected_file != file, info: !selected_file || selected_file === file}' ng-click='select_file(file, "include")')
                 td
                 td
                 td
                   i.fa.fa-file-o
                   |  
                   | {{file.name}}
-              tr.cursor-pointer(ng-if='selected_project.parameters.language === "C" && selected_project === project && active_user.data.mode !== "Simple"' ng-class='{active: selected_file, info: !selected_file}' ng-click='show_add_include_file_modal()')
+              tr.cursor-pointer(ng-if='(selected_project.parameters.language === "C" || selected_project.parameters.language === "C++") && selected_project === project && active_user.data.mode !== "Simple"' ng-class='{active: selected_file, info: !selected_file}' ng-click='show_add_include_file_modal()')
                  td
                  td
                  td
@@ -259,6 +259,7 @@ block view-content
               select#programmingLanguage.form-control(placeholder='Programming Language', ng-model="defaultProgrammingLanguage", ng-change="change_filename()")
                 option(value='C') C
                 option(value='Python') Python
+                option(value="C++") C++
               label(for='sourceFileName') Source file name
               input#sourceFileName.form-control(type='text' value='main.c' disabled='disabled')
 

--- a/apps/kiss/resources/kiss-view-controller.js
+++ b/apps/kiss/resources/kiss-view-controller.js
@@ -1,6 +1,7 @@
 var code_mirror;
 
-require('codemirror/mode/clike/clike');
+require('codemirror/mode/clike/clike');  // allows c/c++ highlighting
+require('codemirror/mode/python/python');  // allows real python highlighting
 
 code_mirror = require('codemirror/lib/codemirror');
 
@@ -8,48 +9,41 @@ Io = require('socket.io-client');
 
 exports.name = 'KissViewController';
 
-exports.inject = function(app) {
+exports.inject = function (app) {
   app.controller(exports.name, ['$scope', '$rootScope', '$location', '$http', '$timeout', 'AppCatalogProvider', 'ProgramService', 'ButtonsOnlyModalFactory', 'DownloadProjectModalFactory', 'FilenameModalFactory', exports.controller]);
 };
 
-exports.controller = function($scope, $rootScope, $location, $http, $timeout, AppCatalogProvider, ProgramService, ButtonsOnlyModalFactory, DownloadProjectModalFactory, FilenameModalFactory) {
+exports.controller = function ($scope, $rootScope, $location, $http, $timeout, AppCatalogProvider, ProgramService, ButtonsOnlyModalFactory, DownloadProjectModalFactory, FilenameModalFactory) {
   var compile, editor, onRouteChangeOff, on_window_beforeunload, save_file, saving, mode;
-  mode = "text/x-csrc"
+  mode = "text/x-csrc"  // c by default
   $scope.is_compiling = false;
   $scope.documentChanged = false;
   $scope.ProgramService = ProgramService;
-  $scope.$on('$routeUpdate', function(next, current) {
+  $scope.$on('$routeUpdate', function (next, current) {
     var ref, ref1;
     if ((((ref = $scope.displayed_file) != null ? ref.name : void 0) !== $location.search().file) || (((ref1 = $scope.selected_project) != null ? ref1.name : void 0) !== $location.search().project)) {
       $scope.reload_ws();
-      console.log("displayed file");
-      console.log($scope.displayed_file);
-      console.log("other thing");
-      console.log($location.search().file);
       let cur_file = $location.search().file;
-      
+
       mode = "text/x-";
-      if (cur_file == undefined){
+      if (cur_file == undefined) {
         // default is just c formatting
         mode += "csrc";
       }
-      else if (cur_file.includes(".cpp")){
+      else if (cur_file.includes(".cpp")) {
         mode += "c++src";
       }
-      else if (cur_file.includes(".c")){
+      else if (cur_file.includes(".c")) {
         mode += "csrc";
       }
-      else if (cur_file.includes(".py")){
+      else if (cur_file.includes(".py")) {
         mode += "python"
       }
-      console.log("using mode" + mode);
-      if (editor != null){
+      if (editor != null) {
         editor.setOption("mode", mode);
-        console.log(editor);
-      } 
+      }
     }
   });
-  // used to be here
   editor = code_mirror.fromTextArea(document.getElementById('editor'), {
     mode: mode,
     lineNumbers: true,
@@ -60,29 +54,29 @@ exports.controller = function($scope, $rootScope, $location, $http, $timeout, Ap
     viewportMargin: Infinity
   });
 
-  editor.on('change', function(e, obj) {
-    $timeout(function() {
+  editor.on('change', function (e, obj) {
+    $timeout(function () {
       $scope.documentChanged = true;
     });
   });
   saving = false;
-  editor.on('beforeChange', function(e, obj) {
+  editor.on('beforeChange', function (e, obj) {
     if (saving) {
       obj.cancel();
     }
   });
 
-  sort_users = function(users) {
-    users.sort( 
-      function(a, b) {
+  sort_users = function (users) {
+    users.sort(
+      function (a, b) {
         var nameA = a.name.toUpperCase();
         var nameB = b.name.toUpperCase();
 
-        if (nameA === "DEFAULT USER"){
+        if (nameA === "DEFAULT USER") {
           return -1;
         }
 
-        if (nameB === "DEFAULT USER"){
+        if (nameB === "DEFAULT USER") {
           return 1;
         }
 
@@ -99,17 +93,17 @@ exports.controller = function($scope, $rootScope, $location, $http, $timeout, Ap
     return users;
   }
 
-  $scope.reload_ws = function() {
-    return AppCatalogProvider.catalog.then(function(app_catalog) {
+  $scope.reload_ws = function () {
+    return AppCatalogProvider.catalog.then(function (app_catalog) {
       var projects_resource, ref, ref1;
       projects_resource = (ref = app_catalog['Programs']) != null ? (ref1 = ref.web_api) != null ? ref1.projects : void 0 : void 0;
       if (projects_resource != null) {
-        $http.get(projects_resource.uri + '/' + $scope.active_user.name).success(function(data, status, headers, config) {
+        $http.get(projects_resource.uri + '/' + $scope.active_user.name).success(function (data, status, headers, config) {
           var project, selected;
           $scope.ws = data;
-          $scope.ws.projects = ($scope.ws.projects || []).filter(function(p) { return p.parameters.user === $scope.active_user.name; }).sort();
+          $scope.ws.projects = ($scope.ws.projects || []).filter(function (p) { return p.parameters.user === $scope.active_user.name; }).sort();
           if ($location.search().project != null) {
-            selected = (function() {
+            selected = (function () {
               var i, len, ref2, results;
               ref2 = $scope.ws.projects;
               results = [];
@@ -129,36 +123,36 @@ exports.controller = function($scope, $rootScope, $location, $http, $timeout, Ap
 
           }
         });
-        $http.get(projects_resource.uri + '/users').success(function(data, status, headers, config) {
-          $scope.users = Object.keys(data).map(function(user, i) { return {id: i, name: user, data: data[user]}; });
+        $http.get(projects_resource.uri + '/users').success(function (data, status, headers, config) {
+          $scope.users = Object.keys(data).map(function (user, i) { return { id: i, name: user, data: data[user] }; });
           $scope.users = sort_users($scope.users);
         });
       }
     });
   };
   $scope.reload_ws();
-  $scope.delete_project = function(project) {
-    return ButtonsOnlyModalFactory.open('Delete Project', 'Are you sure you want to permanently delete this project?', ['Yes', 'No']).then(function(button) {
+  $scope.delete_project = function (project) {
+    return ButtonsOnlyModalFactory.open('Delete Project', 'Are you sure you want to permanently delete this project?', ['Yes', 'No']).then(function (button) {
       if (button === 'Yes') {
         $scope.close_project();
-        return $http["delete"](project.links.self.href).success(function(data, status, headers, config) {
+        return $http["delete"](project.links.self.href).success(function (data, status, headers, config) {
           return $scope.reload_ws();
         });
       }
     });
   };
-  $scope.close_project = function() {
+  $scope.close_project = function () {
     $scope.close_file();
     $scope.project_resource = null;
     $location.search('project', null);
     return $scope.selected_project = null;
   };
-  $scope.select_project = function(project) {
+  $scope.select_project = function (project) {
     $scope.selected_project = project;
     if ($location.search().project !== project.name) {
       $location.search('project', project.name);
     }
-    return $http.get(project.links.self.href).success(function(data, status, headers, config) {
+    return $http.get(project.links.self.href).success(function (data, status, headers, config) {
       var file, selected, selected_file, selected_file_cat;
       $scope.project_resource = data;
       selected_file = null;
@@ -166,7 +160,7 @@ exports.controller = function($scope, $rootScope, $location, $http, $timeout, Ap
       if ($location.search().file != null) {
         selected = [];
         if ($location.search().cat === 'include' && ($scope.project_resource.include_files != null)) {
-          selected = (function() {
+          selected = (function () {
             var i, len, ref, results;
             ref = $scope.project_resource.include_files;
             results = [];
@@ -179,7 +173,7 @@ exports.controller = function($scope, $rootScope, $location, $http, $timeout, Ap
             return results;
           })();
         } else if ($location.search().cat === 'src' && ($scope.project_resource.source_files != null)) {
-          selected = (function() {
+          selected = (function () {
             var i, len, ref, results;
             ref = $scope.project_resource.source_files;
             results = [];
@@ -192,7 +186,7 @@ exports.controller = function($scope, $rootScope, $location, $http, $timeout, Ap
             return results;
           })();
         } else if ($location.search().cat === 'data' && ($scope.project_resource.data_files != null)) {
-          selected = (function() {
+          selected = (function () {
             var i, len, ref, results;
             ref = $scope.project_resource.data_files;
             results = [];
@@ -219,24 +213,24 @@ exports.controller = function($scope, $rootScope, $location, $http, $timeout, Ap
       }
     });
   };
-  $scope.select_file = function(file, file_type) {
+  $scope.select_file = function (file, file_type) {
     $scope.selected_file = file;
     $scope.compiler_output = '';
     $location.search('file', file.name);
     $location.search('cat', file_type);
-    $http.get($scope.selected_file.links.self.href).success(function(data, status, headers, config) {
+    $http.get($scope.selected_file.links.self.href).success(function (data, status, headers, config) {
       $scope.display_file_menu = false;
       $scope.displayed_file = data;
-      $timeout(function() {
+      $timeout(function () {
         editor.setValue(new Buffer(data.content, 'base64').toString('ascii'));
         editor.refresh();
-        return $timeout(function() {
+        return $timeout(function () {
           return $scope.documentChanged = false;
         });
       });
     });
   };
-  $scope.close_file = function() {
+  $scope.close_file = function () {
     $scope.compiler_output = '';
     $scope.display_file_menu = false;
     $scope.displayed_file = null;
@@ -246,19 +240,17 @@ exports.controller = function($scope, $rootScope, $location, $http, $timeout, Ap
     $location.search('file', null);
     return $location.search('cat', null);
   };
-  $scope.delete_file = function(file) {
+  $scope.delete_file = function (file) {
     const project_resource = $scope.project_resource;
     const total_files = project_resource.include_files.length + project_resource.source_files.length + project_resource.data_files.length;
-    if(total_files === 1)
-    {
-      return ButtonsOnlyModalFactory.open('Delete Project', 'This is the last file in the project. Do you want to delete the project?', ['Yes', 'No']).then(function(button) {
-        if (button !== 'Yes')
-        {
+    if (total_files === 1) {
+      return ButtonsOnlyModalFactory.open('Delete Project', 'This is the last file in the project. Do you want to delete the project?', ['Yes', 'No']).then(function (button) {
+        if (button !== 'Yes') {
           // We have to delete project if it is the last file in simple mode
           // because simple mode doesn't allow another means to upload
           if ($scope.active_user.data.mode === "Simple") return;
 
-          return ButtonsOnlyModalFactory.open('Delete File', 'Are you sure you want to permanently delete this file (' + file.name + ') ?', ['Yes', 'No']).then(function(button) {
+          return ButtonsOnlyModalFactory.open('Delete File', 'Are you sure you want to permanently delete this file (' + file.name + ') ?', ['Yes', 'No']).then(function (button) {
             if (button !== 'Yes') return;
             $http["delete"](file.links.self.href);
             $scope.close_file();
@@ -267,20 +259,20 @@ exports.controller = function($scope, $rootScope, $location, $http, $timeout, Ap
         }
         const project = $scope.selected_project;
         $scope.close_project();
-        return $http["delete"](project.links.self.href).success(function(data, status, headers, config) {
+        return $http["delete"](project.links.self.href).success(function (data, status, headers, config) {
           return $scope.reload_ws();
         });
       });
     }
 
-    return ButtonsOnlyModalFactory.open('Delete File', 'Are you sure you want to permanently delete this file (' + file.name + ') ?', ['Yes', 'No']).then(function(button) {
+    return ButtonsOnlyModalFactory.open('Delete File', 'Are you sure you want to permanently delete this file (' + file.name + ') ?', ['Yes', 'No']).then(function (button) {
       if (button !== 'Yes') return;
       $http["delete"](file.links.self.href);
       $scope.close_file();
       $scope.select_project($scope.selected_project);
     });
   };
-  save_file = function() {
+  save_file = function () {
     var content;
     if ($scope.displayed_file != null) {
       content = editor.getValue();
@@ -291,18 +283,18 @@ exports.controller = function($scope, $rootScope, $location, $http, $timeout, Ap
       });
     }
   };
-  $scope.save = function() {
+  $scope.save = function () {
     if ($scope.displayed_file != null) {
       saving = true;
-      save_file().success(function(data, status, headers, config) {
+      save_file().success(function (data, status, headers, config) {
         saving = false;
         $scope.documentChanged = false;
-      }).error(function(data, status, headers, config) {
+      }).error(function (data, status, headers, config) {
         saving = false;
       });
     }
   };
-  on_window_beforeunload = function() {
+  on_window_beforeunload = function () {
     if ($scope.documentChanged) {
       return 'You have unsaved changes. Are you sure you want to leave this page and discard your changes?';
     } else {
@@ -310,7 +302,7 @@ exports.controller = function($scope, $rootScope, $location, $http, $timeout, Ap
     }
   };
   window.addEventListener('beforeunload', on_window_beforeunload);
-  onRouteChangeOff = $rootScope.$on('$locationChangeStart', function(event, newUrl) {
+  onRouteChangeOff = $rootScope.$on('$locationChangeStart', function (event, newUrl) {
     // workaround to detect in-app url updates
     if (newUrl.indexOf('/#/apps/kiss') !== -1) {
       return;
@@ -322,7 +314,7 @@ exports.controller = function($scope, $rootScope, $location, $http, $timeout, Ap
     // remove host:port
     newUrl = newUrl.substring($location.absUrl().length - ($location.url().length));
     if ($scope.documentChanged) {
-      ButtonsOnlyModalFactory.open('You have unsaved changes', 'You have unsaved changes! Would you like to save them before leaving this page?', ['Save', 'Discard', 'Cancel']).then(function(button) {
+      ButtonsOnlyModalFactory.open('You have unsaved changes', 'You have unsaved changes! Would you like to save them before leaving this page?', ['Save', 'Discard', 'Cancel']).then(function (button) {
         if (button === 'Save') {
           $scope.save();
           $location.path(newUrl.substring($location.absUrl().length - ($location.url().length)));
@@ -340,18 +332,18 @@ exports.controller = function($scope, $rootScope, $location, $http, $timeout, Ap
       window.removeEventListener('beforeunload', on_window_beforeunload);
     }
   });
-  $scope.refresh = function() {};
-  $scope.undo = function() {
+  $scope.refresh = function () { };
+  $scope.undo = function () {
     editor.undo();
   };
-  $scope.redo = function() {
+  $scope.redo = function () {
     editor.redo();
   };
-  $scope.download_project = function(project) {
+  $scope.download_project = function (project) {
     return DownloadProjectModalFactory.open(project);
   };
-  $scope.show_add_include_file_modal = function() {
-    return FilenameModalFactory.open('Create New Include File', 'Filename', ['.h'], 'Create').then(function(mData) {
+  $scope.show_add_include_file_modal = function () {
+    return FilenameModalFactory.open('Create New Include File', 'Filename', ['.h'], 'Create').then(function (mData) {
       if ($scope.ws == null || $scope.project_resource == null) return;
 
       var file = {
@@ -360,14 +352,14 @@ exports.controller = function($scope, $rootScope, $location, $http, $timeout, Ap
         content: mData.upload ? window.btoa(mData.upload.content) : ''
       };
 
-      return $http.post($scope.project_resource.links.include_directory.href, file).success(function(data, status, headers, config) {
+      return $http.post($scope.project_resource.links.include_directory.href, file).success(function (data, status, headers, config) {
         $scope.select_file(file, "include");
         return $scope.select_project($scope.selected_project);
       });
     });
   };
 
-  $scope.show_add_source_file_modal = function() {
+  $scope.show_add_source_file_modal = function () {
     var language_array = ['.c'];
     if ($scope.project_resource.parameters.language === 'Python') {
       language_array = ['.py'];
@@ -376,7 +368,7 @@ exports.controller = function($scope, $rootScope, $location, $http, $timeout, Ap
       language_array = ['.cpp'];
     }
 
-    return FilenameModalFactory.open('Create New Source File', 'Filename', language_array, 'Create').then(function(mData) {
+    return FilenameModalFactory.open('Create New Source File', 'Filename', language_array, 'Create').then(function (mData) {
       if ($scope.ws == null || $scope.project_resource == null) return;
 
       var file = {
@@ -385,15 +377,15 @@ exports.controller = function($scope, $rootScope, $location, $http, $timeout, Ap
         content: mData.upload ? window.btoa(mData.upload.content) : ''
       };
 
-      return $http.post($scope.project_resource.links.src_directory.href, file).success(function(data, status, headers, config) {
+      return $http.post($scope.project_resource.links.src_directory.href, file).success(function (data, status, headers, config) {
         $scope.select_file(file, "src");
         return $scope.select_project($scope.selected_project);
       });
     });
   };
 
-  $scope.show_add_data_file_modal = function() {
-    return FilenameModalFactory.open('Create User Data File', 'Filename', null, 'Create').then(function(mData) {
+  $scope.show_add_data_file_modal = function () {
+    return FilenameModalFactory.open('Create User Data File', 'Filename', null, 'Create').then(function (mData) {
       if ($scope.ws == null || $scope.project_resource == null) return;
 
       var file = {
@@ -402,30 +394,30 @@ exports.controller = function($scope, $rootScope, $location, $http, $timeout, Ap
         content: mData.upload ? window.btoa(mData.upload.content) : ''
       };
 
-      return $http.post($scope.project_resource.links.data_directory.href, file).success(function(data, status, headers, config) {
+      return $http.post($scope.project_resource.links.data_directory.href, file).success(function (data, status, headers, config) {
         $scope.select_file(file, "data");
         return $scope.select_project($scope.selected_project);
       });
     });
   };
 
-  $scope.close_file_menu = function() {
+  $scope.close_file_menu = function () {
     return $scope.display_file_menu = false;
   };
-  $scope.open_file_menu = function() {
+  $scope.open_file_menu = function () {
     return $scope.display_file_menu = true;
   };
-  $scope.show_add_project_modal = function() {
+  $scope.show_add_project_modal = function () {
     $scope.change_filename();
     $('#projectName').val(undefined);
     $('#new-project').modal('show');
   };
-  $scope.hide_add_project_modal = function() {
+  $scope.hide_add_project_modal = function () {
     $('#new-project').modal('hide');
   };
-  $scope.add_project = function() {
+  $scope.add_project = function () {
     $('#new-project').modal('hide');
-    AppCatalogProvider.catalog.then(function(app_catalog) {
+    AppCatalogProvider.catalog.then(function (app_catalog) {
       var projects_resource, ref, ref1;
       projects_resource = (ref = app_catalog['Programs']) != null ? (ref1 = ref.web_api) != null ? ref1.projects : void 0 : void 0;
       if (projects_resource != null) {
@@ -434,7 +426,7 @@ exports.controller = function($scope, $rootScope, $location, $http, $timeout, Ap
           user: $scope.active_user.name,
           language: $("#programmingLanguage").val(),
           src_file_name: $("#sourceFileName").val()
-        }).success(function(data, status, headers, config) {
+        }).success(function (data, status, headers, config) {
           $location.search('project', $("#projectName").val());
           $scope.reload_ws();
         });
@@ -442,7 +434,7 @@ exports.controller = function($scope, $rootScope, $location, $http, $timeout, Ap
     });
   };
   $scope.defaultProgrammingLanguage = 'C';
-  $scope.change_filename = function() {
+  $scope.change_filename = function () {
     if ($("#programmingLanguage").val() === "Python") {
       $("#sourceFileName").val("main.py");
     } else if ($("#programmingLanguage").val() === "C") {
@@ -453,46 +445,46 @@ exports.controller = function($scope, $rootScope, $location, $http, $timeout, Ap
       $("#sourceFileName").val("main.cpp");
     }
   };
-  $scope.indent = function() {
+  $scope.indent = function () {
     editor.execCommand('selectAll');
     editor.execCommand('indentAuto');
     editor.setCursor(editor.lineCount(), 0);
   };
 
   $scope.users = [
-    {id: 0, name: 'Default User'}
+    { id: 0, name: 'Default User' }
   ];
   $scope.active_user = $scope.users[0];
 
-  $scope.show_new_user_modal = function() {
+  $scope.show_new_user_modal = function () {
     $('#new-user').modal('show');
   };
-  $scope.hide_new_user_modal = function() {
+  $scope.hide_new_user_modal = function () {
     $('#new-user').modal('hide');
   };
 
-  $scope.add_user = function() {
+  $scope.add_user = function () {
     $scope.show_new_user_modal();
   };
 
-  $scope.new_user = function() {
+  $scope.new_user = function () {
     $('#new-user').modal('hide');
 
     var username = $("#userName").val();
-    AppCatalogProvider.catalog.then(function(app_catalog) {
+    AppCatalogProvider.catalog.then(function (app_catalog) {
       var projects_resource, ref, ref1;
       projects_resource = (ref = app_catalog['Programs']) != null ? (ref1 = ref.web_api) != null ? ref1.projects : void 0 : void 0;
       if (!projects_resource) return;
-      $http.put(projects_resource.uri + '/users/' + username).success(function(data, status) {
-        if(status !== 204) throw new Error('Failed to create new user');
+      $http.put(projects_resource.uri + '/users/' + username).success(function (data, status) {
+        if (status !== 204) throw new Error('Failed to create new user');
 
-          // reload users
-          $http.get(projects_resource.uri + '/users').success(function(data, status, headers, config) {
-            $scope.users = Object.keys(data).map(function(user, i) { return {id: i, name: user, data: data[user]}; });
-            $scope.active_user = $scope.users.filter(function(user) {
-              return user.name === username;
-            })[0] || $scope.active_user;
-          });
+        // reload users
+        $http.get(projects_resource.uri + '/users').success(function (data, status, headers, config) {
+          $scope.users = Object.keys(data).map(function (user, i) { return { id: i, name: user, data: data[user] }; });
+          $scope.active_user = $scope.users.filter(function (user) {
+            return user.name === username;
+          })[0] || $scope.active_user;
+        });
       });
     });
 
@@ -500,39 +492,39 @@ exports.controller = function($scope, $rootScope, $location, $http, $timeout, Ap
   }
 
 
-  $scope.remove_active_user = function() {
+  $scope.remove_active_user = function () {
     var username = $scope.active_user.name;
-    return ButtonsOnlyModalFactory.open('Remove User', 'Are you sure you want to permanently remove ' + username + ' and all of their projects?', ['Yes', 'No']).then(function(button) {
+    return ButtonsOnlyModalFactory.open('Remove User', 'Are you sure you want to permanently remove ' + username + ' and all of their projects?', ['Yes', 'No']).then(function (button) {
       if (button !== 'Yes') return;
 
-      AppCatalogProvider.catalog.then(function(app_catalog) {
+      AppCatalogProvider.catalog.then(function (app_catalog) {
         var projects_resource, ref, ref1;
         projects_resource = (ref = app_catalog['Programs']) != null ? (ref1 = ref.web_api) != null ? ref1.projects : void 0 : void 0;
         if (!projects_resource) return;
-        $http.delete(projects_resource.uri + '/users/' + username).success(function(data, status) {
-          if(status !== 204) throw new Error('Failed to create new user');
+        $http.delete(projects_resource.uri + '/users/' + username).success(function (data, status) {
+          if (status !== 204) throw new Error('Failed to create new user');
           $scope.reload_ws().then(function () {
             $scope.active_user = $scope.users[0];
           });
         });
       });
     });
-    
+
   }
 
-  $scope.$watch('active_user', function(newValue, oldValue) {
+  $scope.$watch('active_user', function (newValue, oldValue) {
     $scope.close_project();
     $scope.close_file();
     $scope.reload_ws();
   });
 
-  compile = function(project_name) {
+  compile = function (project_name) {
     //$scope.stop();
     $scope.is_compiling = true;
     return $http.post('/api/compile', {
       name: project_name,
       user: $scope.active_user.name
-    }).success(function(data, status, headers, config) {
+    }).success(function (data, status, headers, config) {
       var ref;
       $scope.is_compiling = false;
       if (data.result.error != null) {
@@ -551,11 +543,11 @@ exports.controller = function($scope, $rootScope, $location, $http, $timeout, Ap
       }
     });
   };
-  $scope.compile = function() {
+  $scope.compile = function () {
     $scope.compiler_output = null;
     if ($scope.selected_project != null) {
       if ($scope.displayed_file != null) {
-        return save_file().success(function(data, status, headers, config) {
+        return save_file().success(function (data, status, headers, config) {
           $scope.documentChanged = false;
           return compile($scope.selected_project.name);
         });
@@ -565,25 +557,25 @@ exports.controller = function($scope, $rootScope, $location, $http, $timeout, Ap
     }
   };
 
-  AppCatalogProvider.catalog.then(function(app_catalog) {
+  AppCatalogProvider.catalog.then(function (app_catalog) {
     var events_namespace, ref, ref1, ref2, ref3;
     events = (ref = app_catalog['Runner']) != null ? (ref1 = ref.event_groups) != null ? ref1.runner_events.events : void 0 : void 0;
     events_namespace = (ref2 = app_catalog['Runner']) != null ? (ref3 = ref2.event_groups) != null ? ref3.runner_events.namespace : void 0 : void 0;
     if (events != null) {
       socket = Io(':8888' + events_namespace);
-      return socket.on(events.stdout.id, function(msg) {
+      return socket.on(events.stdout.id, function (msg) {
         return $scope.$broadcast('runner-program-output', msg);
       });
     }
   });
-  $scope.$on('runner-program-input', function(event, text) {
+  $scope.$on('runner-program-input', function (event, text) {
     if ((socket != null) && (events != null)) {
       return socket.emit(events.stdin.id, text);
     }
   });
-  $scope.run = function() {
-  if ($scope.selected_project != null) {
-    if($scope.is_compiling != true) {
+  $scope.run = function () {
+    if ($scope.selected_project != null) {
+      if ($scope.is_compiling != true) {
         $scope.img_src = null;
         $scope.$broadcast("runner-reset-terminal");
         $scope.runner = true;
@@ -592,16 +584,16 @@ exports.controller = function($scope, $rootScope, $location, $http, $timeout, Ap
       }
     }
   };
-  $scope.toggle_run = function() {
-    if(ProgramService.running) return $scope.stop();
+  $scope.toggle_run = function () {
+    if (ProgramService.running) return $scope.stop();
     return $scope.run();
   }
-  $scope.hide_runner = function() {
+  $scope.hide_runner = function () {
     $scope.runner = false;
   }
-  return $scope.stop = function() {
+  return $scope.stop = function () {
     $scope.is_compiling = false;
-    if(!ProgramService.running) return;
+    if (!ProgramService.running) return;
     return ProgramService.stop();
   };
 };

--- a/apps/kiss/resources/kiss-view-controller.js
+++ b/apps/kiss/resources/kiss-view-controller.js
@@ -13,18 +13,45 @@ exports.inject = function(app) {
 };
 
 exports.controller = function($scope, $rootScope, $location, $http, $timeout, AppCatalogProvider, ProgramService, ButtonsOnlyModalFactory, DownloadProjectModalFactory, FilenameModalFactory) {
-  var compile, editor, onRouteChangeOff, on_window_beforeunload, save_file, saving;
+  var compile, editor, onRouteChangeOff, on_window_beforeunload, save_file, saving, mode;
+  mode = "text/x-csrc"
   $scope.is_compiling = false;
   $scope.documentChanged = false;
   $scope.ProgramService = ProgramService;
   $scope.$on('$routeUpdate', function(next, current) {
     var ref, ref1;
     if ((((ref = $scope.displayed_file) != null ? ref.name : void 0) !== $location.search().file) || (((ref1 = $scope.selected_project) != null ? ref1.name : void 0) !== $location.search().project)) {
-      return $scope.reload_ws();
+      $scope.reload_ws();
+      console.log("displayed file");
+      console.log($scope.displayed_file);
+      console.log("other thing");
+      console.log($location.search().file);
+      let cur_file = $location.search().file;
+      
+      mode = "text/x-";
+      if (cur_file == undefined){
+        // default is just c formatting
+        mode += "csrc";
+      }
+      else if (cur_file.includes(".cpp")){
+        mode += "c++src";
+      }
+      else if (cur_file.includes(".c")){
+        mode += "csrc";
+      }
+      else if (cur_file.includes(".py")){
+        mode += "python"
+      }
+      console.log("using mode" + mode);
+      if (editor != null){
+        editor.setOption("mode", mode);
+        console.log(editor);
+      } 
     }
   });
+  // used to be here
   editor = code_mirror.fromTextArea(document.getElementById('editor'), {
-    mode: 'text/x-csrc',
+    mode: mode,
     lineNumbers: true,
     indentUnit: 4,
     smartIndent: false,
@@ -32,6 +59,7 @@ exports.controller = function($scope, $rootScope, $location, $http, $timeout, Ap
     theme: 'kiss',
     viewportMargin: Infinity
   });
+
   editor.on('change', function(e, obj) {
     $timeout(function() {
       $scope.documentChanged = true;
@@ -344,6 +372,10 @@ exports.controller = function($scope, $rootScope, $location, $http, $timeout, Ap
     if ($scope.project_resource.parameters.language === 'Python') {
       language_array = ['.py'];
     }
+    if ($scope.project_resource.parameters.language === 'C++') {
+      language_array = ['.cpp'];
+    }
+
     return FilenameModalFactory.open('Create New Source File', 'Filename', language_array, 'Create').then(function(mData) {
       if ($scope.ws == null || $scope.project_resource == null) return;
 
@@ -413,8 +445,12 @@ exports.controller = function($scope, $rootScope, $location, $http, $timeout, Ap
   $scope.change_filename = function() {
     if ($("#programmingLanguage").val() === "Python") {
       $("#sourceFileName").val("main.py");
-    } else {
+    } else if ($("#programmingLanguage").val() === "C") {
       $("#sourceFileName").val("main.c");
+    }
+    else {
+      // it's c++
+      $("#sourceFileName").val("main.cpp");
     }
   };
   $scope.indent = function() {


### PR DESCRIPTION
Changes introduced:
* This allows for creating a file `config.json` that looks like the following: `{"compilerArgs" : ["-std=c11", "-O3", ...]}`. Note that the file must be called config.json and the property must be compilerArgs (both are case sensitive).
* Allows for creating c++ projects and compiling them. 
* Adds support for different syntax highlighting for c, c++, and python.

Tested:
- [x] compiling c++
- [x] syntax highlighting
- [x] config.json compiler arguments