### PR TITLE
Highlight .h and .hpp files

### DIFF
--- a/apps/kiss/resources/kiss-view-controller.js
+++ b/apps/kiss/resources/kiss-view-controller.js
@@ -30,14 +30,17 @@ exports.controller = function ($scope, $rootScope, $location, $http, $timeout, A
         // default is just c formatting
         mode += "csrc";
       }
-      else if (cur_file.includes(".cpp")) {
+      else if (cur_file.includes(".cpp") || cur_file.includes(".hpp")) {
         mode += "c++src";
       }
-      else if (cur_file.includes(".c")) {
+      else if (cur_file.includes(".c") || cur_file.includes(".h")) {
         mode += "csrc";
       }
       else if (cur_file.includes(".py")) {
         mode += "python"
+      }
+      else {
+        mode += "csrc" // by default, use c highlighting
       }
       if (editor != null) {
         editor.setOption("mode", mode);


### PR DESCRIPTION
This is a fix for my previous pr. I forgot to highlight .h files w/ c highlighting and .hpp files with c++ highlighting. Also forgot to make sure that, if the file is neither c, c++, or py, use csrc highlighting.